### PR TITLE
move testAppEngine from neo-test to lib bctk

### DIFF
--- a/src/bctklib-3/smart-contract/TestApplicationEngine.TestVerifiable.cs
+++ b/src/bctklib-3/smart-contract/TestApplicationEngine.TestVerifiable.cs
@@ -7,7 +7,7 @@ namespace Neo.BlockchainToolkit.SmartContract
 {
     public partial class TestApplicationEngine
     {
-        public class TestVerifiable : IVerifiable
+        class TestVerifiable : IVerifiable
         {
             readonly UInt160[] signers;
 
@@ -23,7 +23,7 @@ namespace Neo.BlockchainToolkit.SmartContract
                 get => throw new NotImplementedException(); 
                 set => throw new NotImplementedException(); 
             }
-            
+
             public int Size => throw new NotImplementedException();
             public void Deserialize(BinaryReader reader) => throw new NotImplementedException();
             public void DeserializeUnsigned(BinaryReader reader) => throw new NotImplementedException();

--- a/src/bctklib-3/smart-contract/TestApplicationEngine.TestVerifiable.cs
+++ b/src/bctklib-3/smart-contract/TestApplicationEngine.TestVerifiable.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+
+namespace Neo.BlockchainToolkit.SmartContract
+{
+    public partial class TestApplicationEngine
+    {
+        public class TestVerifiable : IVerifiable
+        {
+            readonly UInt160[] signers;
+
+            public TestVerifiable(params UInt160[] signers)
+            {
+                this.signers = signers;
+            }
+
+            public UInt160[] GetScriptHashesForVerifying(DataCache snapshot) => signers;
+
+            public Witness[] Witnesses 
+            { 
+                get => throw new NotImplementedException(); 
+                set => throw new NotImplementedException(); 
+            }
+            
+            public int Size => throw new NotImplementedException();
+            public void Deserialize(BinaryReader reader) => throw new NotImplementedException();
+            public void DeserializeUnsigned(BinaryReader reader) => throw new NotImplementedException();
+            public void Serialize(BinaryWriter writer) => throw new NotImplementedException();
+            public void SerializeUnsigned(BinaryWriter writer) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/bctklib-3/smart-contract/TestApplicationEngine.cs
+++ b/src/bctklib-3/smart-contract/TestApplicationEngine.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Neo.Cryptography;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.SmartContract;
+
+namespace Neo.BlockchainToolkit.SmartContract
+{
+    using WitnessChecker = Func<byte[], bool>;
+    using ServiceMethod = Func<TestApplicationEngine, IReadOnlyList<InteropParameterDescriptor>, Neo.VM.Types.StackItem?>;
+    using StackItem = Neo.VM.Types.StackItem;
+
+    public partial class TestApplicationEngine : ApplicationEngine
+    {
+        private readonly static IReadOnlyDictionary<uint, ServiceMethod> overriddenServices;
+
+        static TestApplicationEngine()
+        {
+            var builder = ImmutableDictionary.CreateBuilder<uint, ServiceMethod>();
+            builder.Add(HashMethodName("System.Runtime.CheckWitness"), CheckWitnessOverride);
+            overriddenServices = builder.ToImmutable();
+
+            static uint HashMethodName(string name)
+            {
+                return BitConverter.ToUInt32(System.Text.Encoding.ASCII.GetBytes(name).Sha256(), 0);
+            }
+        }
+
+        private readonly WitnessChecker witnessChecker;
+
+        public TestApplicationEngine(DataCache snapshot) : this(TriggerType.Application, null, snapshot, null, ApplicationEngine.TestModeGas, null)
+        {
+        }
+
+        public TestApplicationEngine(DataCache snapshot, UInt160 signer) : this(TriggerType.Application, new TestVerifiable(signer), snapshot, null, ApplicationEngine.TestModeGas, null)
+        {
+        }
+
+        public TestApplicationEngine(TriggerType trigger, IVerifiable? container, DataCache snapshot, Block? persistingBlock, long gas, WitnessChecker? witnessChecker)
+            : base(trigger, container ?? new TestVerifiable(), snapshot, persistingBlock, gas)
+        {
+            this.witnessChecker = witnessChecker ?? CheckWitness;
+            ApplicationEngine.Log += OnLog;
+            ApplicationEngine.Notify += OnNotify;
+        }
+
+        public override void Dispose()
+        {
+            ApplicationEngine.Log -= OnLog;
+            ApplicationEngine.Notify -= OnNotify;
+            base.Dispose();
+        }
+
+        public new event EventHandler<LogEventArgs>? Log;
+        public new event EventHandler<NotifyEventArgs>? Notify;
+
+        private void OnLog(object? sender, LogEventArgs args)
+        {
+            if (ReferenceEquals(this, sender))
+            {
+                this.Log?.Invoke(sender, args);
+            }
+        }
+
+        private void OnNotify(object? sender, NotifyEventArgs args)
+        {
+            if (ReferenceEquals(this, sender))
+            {
+                this.Notify?.Invoke(sender, args);
+            }
+        }
+
+        private static StackItem CheckWitnessOverride(
+            TestApplicationEngine engine,
+            IReadOnlyList<InteropParameterDescriptor> paramDescriptors)
+        {
+
+            Debug.Assert(paramDescriptors.Count == 1);
+            var hashOrPubkey = (byte[])engine.Convert(engine.Pop(), paramDescriptors[0]);
+
+            return engine.witnessChecker.Invoke(hashOrPubkey);
+        }
+
+        protected override void OnSysCall(uint methodHash)
+        {
+            if (overriddenServices.TryGetValue(methodHash, out var method))
+            {
+                InteropDescriptor descriptor = Services[methodHash];
+                ValidateCallFlags(descriptor);
+                AddGas(descriptor.FixedPrice);
+
+                var result = method(this, descriptor.Parameters);
+                if (descriptor.Handler.ReturnType != typeof(void))
+                {
+                    if (result == null) throw new InvalidOperationException($"expected return value from {descriptor.Handler.Name}");
+                    Push(result);
+                }
+                else
+                {
+                    if (result != null) throw new InvalidOperationException($"expected null return value from {descriptor.Handler.Name}");
+                }
+            }
+            else
+            {
+                base.OnSysCall(methodHash);
+            }
+        }
+    }
+}

--- a/src/bctklib-3/trace-models/ScriptRecord.cs
+++ b/src/bctklib-3/trace-models/ScriptRecord.cs
@@ -1,8 +1,6 @@
 using System.Buffers;
-using System.Collections.Generic;
 using MessagePack;
 using Neo.VM;
-using StackItem = Neo.VM.Types.StackItem;
 
 namespace Neo.BlockchainToolkit.TraceDebug
 {
@@ -25,7 +23,7 @@ namespace Neo.BlockchainToolkit.TraceDebug
 
         public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, byte[] script)
         {
-            var scriptHash = SmartContract.Helper.ToScriptHash(script);
+            var scriptHash = Neo.SmartContract.Helper.ToScriptHash(script);
 
             var mpWriter = new MessagePackWriter(writer);
             mpWriter.WriteArrayHeader(2);


### PR DESCRIPTION
`TestApplicationEngine` from neo-test shares significant code w/ `DebugApplicationEngine` from neo-debugger. Since both libraries depend on lib bctk, seems smart to share common code where feasible