### PR TITLE
Workaround neo-devpack-dotnet issues #637

### DIFF
--- a/src/bctklib-3/models/DebugInfo.cs
+++ b/src/bctklib-3/models/DebugInfo.cs
@@ -185,6 +185,19 @@ namespace Neo.BlockchainToolkit.Models
             static IEnumerable<SlotVariable> LoadSlotVariables(JToken token, string propertyName)
             {
                 var vars = EnumToken(token, propertyName).Select(ParseType).ToList();
+
+                // Work around https://github.com/neo-project/neo-devpack-dotnet/issues/637
+                // if a variable list has any slot indexes, but the first variable is "this,Any" remove it
+                if (vars.Any(t => t.slotIndex.HasValue)
+                    && vars.Count > 0
+                    && vars[0].name == "this"
+                    && vars[0].type == "Any"
+                    && !vars[0].slotIndex.HasValue)
+                {
+                    vars.RemoveAt(0);
+                }
+                // end https://github.com/neo-project/neo-devpack-dotnet/issues/637 workaround
+
                 if (vars.Any(t => t.slotIndex.HasValue) && !vars.All(t => t.slotIndex.HasValue))
                 {
                     throw new FormatException("cannot mix and match optional slot index information");

--- a/test/test.bctklib-3/DebugInfoTest.cs
+++ b/test/test.bctklib-3/DebugInfoTest.cs
@@ -18,6 +18,19 @@ namespace test.bctklib3
         const string TEST_HASH = "0xf69e5188632deb3a9273519efc86cb68da8d42b8";
 
         [Fact]
+        public async Task can_load_debug_json_nccs_rc3()
+        {
+            var debugInfoJson = GetResource("nccs_rc3.json");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\fakeContract.nef", new MockFileData("") },
+                { @"c:\fakeContract.debug.json", new MockFileData(debugInfoJson) },
+            });
+            var debugInfo = await DebugInfo.LoadAsync(@"c:\fakeContract.nef", null, fileSystem);
+            Assert.True(debugInfo.IsT0);
+        }
+
+        [Fact]
         public async Task can_load_debug_json()
         {
             var debugInfoJson = GetResource("Registrar.debug.json");

--- a/test/test.bctklib-3/_testFiles/nccs_rc3.json
+++ b/test/test.bctklib-3/_testFiles/nccs_rc3.json
@@ -1,0 +1,291 @@
+{
+    "hash": "0xf69e5188632deb3a9273519efc86cb68da8d42b8",
+    "documents": [
+        "C:\\Users\\harry\\Source\\neo\\seattle\\samples\\registrar-sample\\src\\Registrar.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/ByteString.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/CallingConventionAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/ContractAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/ContractHashAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/ContractParameterType.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/ContractPermissionAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/ContractTrustAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/ECPoint.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/ExecutionEngine.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Helper.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/IApiInterface.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/InitialValueAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/List.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/ManifestExtraAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Map.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/ContractManagement.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/CryptoLib.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/GAS.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/Ledger.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/NamedCurve.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/NEO.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/NeoAccountState.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/Oracle.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/OracleResponseCode.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/Policy.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/Role.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/RoleManagement.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Native/StdLib.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Nep11Token.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Nep11TokenState.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Nep17Token.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/OpCode.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/OpCodeAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Properties/AssemblyInfo.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/SafeAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/Block.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/CallFlags.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/Contract.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/Crypto.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/FindOptions.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/Iterator.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/Notification.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/Runtime.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/Storage.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/StorageContext.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/StorageMap.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/Transaction.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/Services/TriggerType.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/SmartContract.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/StackItemType.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/SupportedStandardsAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/SyscallAttribute.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/TokenContract.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/UInt160.cs",
+        "C:\\Users\\harry\\.nuget\\packages\\neo.smartcontract.framework/3.0.0-rc3\\src/UInt256.cs"
+    ],
+    "static-variables": [],
+    "methods": [
+        {
+            "id": "DevHawk.Contracts.Registrar.Query(string)",
+            "name": "DevHawk.Contracts.Registrar,Query",
+            "range": "0-59",
+            "params": [
+                "this,Any",
+                "domain,String,0"
+            ],
+            "return": "Hash160",
+            "variables": [
+                "currentOwner,Hash160,0"
+            ],
+            "sequence-points": [
+                "3[0]19:9-19:10",
+                "4[0]20:17-20:56",
+                "14[0]21:17-21:36",
+                "22[0]22:13-22:14",
+                "23[0]23:17-23:54",
+                "51[0]24:13-24:14",
+                "53[0]26:13-26:33",
+                "59[0]27:9-27:10"
+            ]
+        },
+        {
+            "id": "DevHawk.Contracts.DomainStorage.Get(string)",
+            "name": "DevHawk.Contracts.DomainStorage,Get",
+            "range": "60-129",
+            "params": [
+                "this,Any",
+                "domain,String,0"
+            ],
+            "return": "Hash160",
+            "variables": [],
+            "sequence-points": [
+                "63[0]118:46-118:93"
+            ]
+        },
+        {
+            "id": "DevHawk.Contracts.DomainStorage.DomainStorage(string)",
+            "name": "DevHawk.Contracts.DomainStorage,.ctor",
+            "range": "212-230",
+            "params": [
+                "this,Any",
+                "prefix,String,0"
+            ],
+            "return": "Void",
+            "variables": [],
+            "sequence-points": [
+                "215[0]114:9-114:10",
+                "216[0]115:13-115:73",
+                "230[0]116:9-116:10"
+            ]
+        },
+        {
+            "id": "DevHawk.Contracts.Registrar.Register(string, Neo.UInt160)",
+            "name": "DevHawk.Contracts.Registrar,Register",
+            "range": "244-377",
+            "params": [
+                "this,Any",
+                "domain,String,0",
+                "owner,Hash160,1"
+            ],
+            "return": "Boolean",
+            "variables": [
+                "currentOwner,Hash160,0"
+            ],
+            "sequence-points": [
+                "247[0]30:9-30:10",
+                "248[0]31:17-31:56",
+                "258[0]32:17-32:37",
+                "267[0]33:13-33:14",
+                "268[0]34:17-34:58",
+                "300[0]35:17-35:30",
+                "308[0]36:13-36:14",
+                "310[0]37:17-37:45",
+                "322[0]38:13-38:14",
+                "323[0]39:17-39:52",
+                "349[0]40:17-40:30",
+                "357[0]41:13-41:14",
+                "359[0]43:13-43:45",
+                "369[0]44:13-44:25",
+                "377[0]45:9-45:10"
+            ]
+        },
+        {
+            "id": "DevHawk.Contracts.DomainStorage.Put(string, Neo.UInt160)",
+            "name": "DevHawk.Contracts.DomainStorage,Put",
+            "range": "384-406",
+            "params": [
+                "this,Any",
+                "domain,String,0",
+                "owner,Hash160,1"
+            ],
+            "return": "Void",
+            "variables": [],
+            "sequence-points": [
+                "387[0]119:58-119:99"
+            ]
+        },
+        {
+            "id": "DevHawk.Contracts.Registrar.Transfer(string, Neo.UInt160)",
+            "name": "DevHawk.Contracts.Registrar,Transfer",
+            "range": "422-630",
+            "params": [
+                "this,Any",
+                "domain,String,0",
+                "to,Hash160,1"
+            ],
+            "return": "Boolean",
+            "variables": [
+                "currentOwner,Hash160,0"
+            ],
+            "sequence-points": [
+                "425[0]48:9-48:10",
+                "426[0]49:17-49:56",
+                "436[0]50:17-50:36",
+                "444[0]51:13-51:14",
+                "445[0]52:17-52:54",
+                "473[0]53:17-53:30",
+                "481[0]54:13-54:14",
+                "483[0]55:17-55:52",
+                "495[0]56:13-56:14",
+                "496[0]57:17-57:70",
+                "540[0]58:17-58:30",
+                "548[0]59:13-59:14",
+                "550[0]60:17-60:42",
+                "562[0]61:13-61:14",
+                "563[0]62:17-62:65",
+                "602[0]63:17-63:30",
+                "610[0]64:13-64:14",
+                "612[0]66:13-66:42",
+                "622[0]67:13-67:25",
+                "630[0]68:9-68:10"
+            ]
+        },
+        {
+            "id": "DevHawk.Contracts.Registrar.Delete(string)",
+            "name": "DevHawk.Contracts.Registrar,Delete",
+            "range": "631-776",
+            "params": [
+                "this,Any",
+                "domain,String,0"
+            ],
+            "return": "Boolean",
+            "variables": [
+                "currentOwner,Hash160,0"
+            ],
+            "sequence-points": [
+                "634[0]71:9-71:10",
+                "635[0]72:17-72:56",
+                "645[0]73:17-73:36",
+                "653[0]74:13-74:14",
+                "654[0]75:17-75:54",
+                "682[0]76:17-76:30",
+                "690[0]77:13-77:14",
+                "692[0]78:17-78:52",
+                "704[0]79:13-79:14",
+                "705[0]80:17-80:70",
+                "749[0]81:17-81:30",
+                "757[0]82:13-82:14",
+                "759[0]84:13-84:41",
+                "768[0]85:13-85:25",
+                "776[0]86:9-86:10"
+            ]
+        },
+        {
+            "id": "DevHawk.Contracts.DomainStorage.Delete(string)",
+            "name": "DevHawk.Contracts.DomainStorage,Delete",
+            "range": "777-797",
+            "params": [
+                "this,Any",
+                "domain,String,0"
+            ],
+            "return": "Void",
+            "variables": [],
+            "sequence-points": [
+                "780[0]120:46-120:71"
+            ]
+        },
+        {
+            "id": "DevHawk.Contracts.Registrar.Deploy(object, bool)",
+            "name": "DevHawk.Contracts.Registrar,Deploy",
+            "range": "812-858",
+            "params": [
+                "this,Any",
+                "data,Any,0",
+                "update,Boolean,1"
+            ],
+            "return": "Void",
+            "variables": [
+                "tx,Any,0"
+            ],
+            "sequence-points": [
+                "815[0]90:9-90:10",
+                "816[0]91:17-91:23",
+                "822[0]91:25-91:32",
+                "828[0]93:17-93:58",
+                "834[0]94:13-94:79",
+                "858[0]95:9-95:10"
+            ]
+        },
+        {
+            "id": "DevHawk.Contracts.Registrar.Update(Neo.SmartContract.Framework.ByteString, string)",
+            "name": "DevHawk.Contracts.Registrar,Update",
+            "range": "871-973",
+            "params": [
+                "nefFile,ByteArray,0",
+                "manifest,String,1"
+            ],
+            "return": "Void",
+            "variables": [
+                "tx,Any,0",
+                "contractOwner,ByteArray,1"
+            ],
+            "sequence-points": [
+                "874[0]98:9-98:10",
+                "875[0]99:17-99:58",
+                "881[0]100:17-100:87",
+                "903[0]101:17-101:49",
+                "914[0]102:13-102:14",
+                "915[0]103:17-103:88",
+                "965[0]104:13-104:14",
+                "967[0]105:13-105:64",
+                "973[0]106:9-106:10"
+            ]
+        }
+    ],
+    "events": []
+}


### PR DESCRIPTION
nccs is emitting variable lists with both implicit and explicit slot indexes (https://github.com/neo-project/neo-devpack-dotnet/issues/637). When there are explicit slot indexes specified, but the list of varialbles starts with "this,Any", discard the "this,Any" variable information. 

Any other case of mixing and matching implicit and explicit slot indexes will continue to throw an exception