### PR TITLE
Cross Platform Path Handling

### DIFF
--- a/eng/azure-ci.yml
+++ b/eng/azure-ci.yml
@@ -34,6 +34,10 @@ stages:
     workspace:
       clean: all
     steps:
+    - script: |
+        sudo apt-get update
+        sudo apt-get install libsnappy-dev libc6-dev librocksdb-dev -y
+      condition: startsWith(variables['image'], 'ubuntu-')
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
@@ -51,11 +55,11 @@ stages:
         command: 'test'
         projects: 'test/test.bctklib-3/test.bctklib-3.csproj'
         arguments: '-c $(buildConfiguration) --no-build --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
-    - task: PublishCodeCoverageResults@1
-      displayName: 'Publish code coverage'
-      inputs:
-        codeCoverageTool: 'Cobertura'
-        summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
+    # - task: PublishCodeCoverageResults@1
+    #   displayName: 'Publish code coverage'
+    #   inputs:
+    #     codeCoverageTool: 'Cobertura'
+    #     summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
     # - task: DotNetCoreCLI@2
     #   displayName: 'dotnet pack'
     #   inputs:

--- a/eng/azure-ci.yml
+++ b/eng/azure-ci.yml
@@ -49,9 +49,8 @@ stages:
       displayName: 'dotnet test'
       inputs:
         command: 'test'
+        projects: 'test/test.bctklib-3/test.bctklib-3.csproj'
         arguments: '-c $(buildConfiguration) --no-build --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
-        publishTestResults: true
-        projects: test.bctklib-3
     - task: PublishCodeCoverageResults@1
       displayName: 'Publish code coverage'
       inputs:

--- a/eng/azure-ci.yml
+++ b/eng/azure-ci.yml
@@ -2,7 +2,6 @@ variables:
   isMasterBranch: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isReleaseBranch: $[startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')]
   azureArtifactsBranch: $[or(eq(variables.isMasterBranch, true), eq(variables.isReleaseBranch, true))]
-  nugetOrgBranch: $[eq(variables.isReleaseBranch, true)]
 
 trigger:
   batch: false
@@ -24,8 +23,14 @@ stages:
     buildConfiguration: Release
   jobs:
   - job:
+    strategy:
+      matrix:
+        'Windows':
+          image: 'windows-2019'
+        'Ubuntu':
+          image: 'ubuntu-20.04'
     pool:
-      vmImage: 'windows-2019'
+      vmImage: $(image)
     workspace:
       clean: all
     steps:
@@ -44,54 +49,30 @@ stages:
       displayName: 'dotnet test'
       inputs:
         command: 'test'
-        arguments: -c $(buildConfiguration) --no-build --collect:"XPlat Code Coverage" --settings ./test/runsettings.xml
+        arguments: '-c $(buildConfiguration) --no-build --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
+        publishTestResults: true
+        projects: test.bctklib-3
     - task: PublishCodeCoverageResults@1
       displayName: 'Publish code coverage'
       inputs:
-          codeCoverageTool: cobertura
-          summaryFileLocation: $(Agent.TempDirectory)/**/coverage.cobertura.xml
-    - task: DotNetCoreCLI@2
-      displayName: 'dotnet pack'
-      inputs:
-        command: 'pack'
-        packagesToPack: 'src/**/*.csproj'
-        includesymbols: true
-        versioningScheme: 'off'
-        arguments: --no-build
-    - publish: '$(Build.ArtifactStagingDirectory)'
-      displayName: 'publish build artifact'
-      artifact: NugetPackage
-    - task: NuGetCommand@2
-      displayName: 'publish package to azure artifacts'
-      condition: and(succeeded(), eq(variables.azureArtifactsBranch, true))
-      inputs:
-        command: 'push'
-        packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-        nuGetFeedType: 'internal'
-        publishVstsFeed: 'c96908c2-e4b5-4c77-b955-4b690f24380b/9e84eb49-63f0-4b48-a8c4-039901073643'
-
-# - stage: publishNugetOrg
-#   displayName: 'publish artifacts to nuget.org'
-#   dependsOn: build
-#   condition: and(succeeded(), eq(variables.nugetOrgBranch, true))
-#   jobs:
-#     - deployment: 
-#       pool:
-#         vmImage: 'ubuntu-latest'
-#       environment: 'nuget-org'
-#       strategy:
-#         runOnce:
-#           deploy:
-#             steps:
-#               - task: NuGetCommand@2
-#                 inputs:
-#                   command: 'push'
-#                   packagesToPush: '$(Pipeline.Workspace)/NugetPackage/*.nupkg'
-#                   nuGetFeedType: 'external'
-#                   publishFeedCredentials: 'nuget-org'
-#               - task: NuGetCommand@2
-#                 inputs:
-#                   command: 'push'
-#                   packagesToPush: '$(Pipeline.Workspace)/NugetPackage/*.snupkg'
-#                   nuGetFeedType: 'external'
-#                   publishFeedCredentials: 'nuget-org'
+        codeCoverageTool: 'Cobertura'
+        summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
+    # - task: DotNetCoreCLI@2
+    #   displayName: 'dotnet pack'
+    #   inputs:
+    #     command: 'pack'
+    #     packagesToPack: 'src/**/*.csproj'
+    #     includesymbols: true
+    #     versioningScheme: 'off'
+    #     arguments: --no-build
+    # - publish: '$(Build.ArtifactStagingDirectory)'
+    #   displayName: 'publish build artifact'
+    #   artifact: NugetPackage
+    # - task: NuGetCommand@2
+    #   displayName: 'publish package to azure artifacts'
+    #   condition: and(succeeded(), eq(variables.azureArtifactsBranch, true))
+    #   inputs:
+    #     command: 'push'
+    #     packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+    #     nuGetFeedType: 'internal'
+    #     publishVstsFeed: 'c96908c2-e4b5-4c77-b955-4b690f24380b/9e84eb49-63f0-4b48-a8c4-039901073643'

--- a/eng/azure-ci.yml
+++ b/eng/azure-ci.yml
@@ -18,11 +18,11 @@ trigger:
     - 'docs/*'
 
 stages:
-- stage: build
+- stage: 
   variables:
     buildConfiguration: Release
   jobs:
-  - job:
+  - job: build
     strategy:
       matrix:
         'Windows':
@@ -55,27 +55,32 @@ stages:
         command: 'test'
         projects: 'test/test.bctklib-3/test.bctklib-3.csproj'
         arguments: '-c $(buildConfiguration) --no-build --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
-    # - task: PublishCodeCoverageResults@1
-    #   displayName: 'Publish code coverage'
-    #   inputs:
-    #     codeCoverageTool: 'Cobertura'
-    #     summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
-    # - task: DotNetCoreCLI@2
-    #   displayName: 'dotnet pack'
-    #   inputs:
-    #     command: 'pack'
-    #     packagesToPack: 'src/**/*.csproj'
-    #     includesymbols: true
-    #     versioningScheme: 'off'
-    #     arguments: --no-build
-    # - publish: '$(Build.ArtifactStagingDirectory)'
-    #   displayName: 'publish build artifact'
-    #   artifact: NugetPackage
-    # - task: NuGetCommand@2
-    #   displayName: 'publish package to azure artifacts'
-    #   condition: and(succeeded(), eq(variables.azureArtifactsBranch, true))
-    #   inputs:
-    #     command: 'push'
-    #     packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-    #     nuGetFeedType: 'internal'
-    #     publishVstsFeed: 'c96908c2-e4b5-4c77-b955-4b690f24380b/9e84eb49-63f0-4b48-a8c4-039901073643'
+  - job: publish
+    dependsOn: build
+    pool:
+      vmImage: 'ubuntu-20.04'
+    workspace:
+      clean: all
+    steps:
+    - task: UseDotNet@2
+      inputs:
+        packageType: 'sdk'
+        useGlobalJson: true
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet pack'
+      inputs:
+        command: 'pack'
+        packagesToPack: 'src/bctklib-3/bctklib-3.csproj'
+        includesymbols: true
+        versioningScheme: 'off'
+    - publish: '$(Build.ArtifactStagingDirectory)'
+      displayName: 'publish build artifact'
+      artifact: NugetPackage
+    - task: NuGetCommand@2
+      displayName: 'publish package to azure artifacts'
+      condition: and(succeeded(), eq(variables.azureArtifactsBranch, true))
+      inputs:
+        command: 'push'
+        packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+        nuGetFeedType: 'internal'
+        publishVstsFeed: 'c96908c2-e4b5-4c77-b955-4b690f24380b/9e84eb49-63f0-4b48-a8c4-039901073643'

--- a/src/bctklib-3/ContractParameterParser.cs
+++ b/src/bctklib-3/ContractParameterParser.cs
@@ -174,7 +174,7 @@ namespace Neo.BlockchainToolkit
 
             if (value.StartsWith("file://"))
             {
-                var file = value[7..];
+                var file = fileSystem.NormalizePath(value[7..]);
                 file = fileSystem.Path.IsPathFullyQualified(file) 
                     ? file
                     : fileSystem.Path.GetFullPath(file, fileSystem.Directory.GetCurrentDirectory());

--- a/src/bctklib-3/Extensions.cs
+++ b/src/bctklib-3/Extensions.cs
@@ -82,6 +82,18 @@ namespace Neo.BlockchainToolkit
             return false;
         }
 
+        internal static string NormalizePath(this IFileSystem fileSystem, string path)
+        {
+            if (fileSystem.Path.DirectorySeparatorChar == '\\')
+            {
+                return fileSystem.Path.GetFullPath(path);
+            }
+            else
+            {
+                return path.Replace('\\', '/');
+            }
+        }
+
         public static ExpressWallet GetWallet(this ExpressChain chain, string name)
             => TryGetWallet(chain, name, out var wallet)
                 ? wallet

--- a/src/bctklib-3/FileNameUtilities.cs
+++ b/src/bctklib-3/FileNameUtilities.cs
@@ -1,0 +1,67 @@
+namespace Neo.BlockchainToolkit
+{
+    // This logic lifted from https://github.com/dotnet/symreader-portable/blob/main/src/Microsoft.DiaSymReader.PortablePdb/Utilities/FileNameUtilities.cs
+    internal static class FileNameUtilities
+    {
+        private const char DirectorySeparatorChar = '\\';
+        private const char AltDirectorySeparatorChar = '/';
+        private const char VolumeSeparatorChar = ':';
+
+        /// <summary>
+        /// Returns the position in given path where the file name starts.
+        /// </summary>
+        /// <returns>-1 if path is null.</returns>
+        internal static int IndexOfFileName(string path)
+        {
+            if (path == null)
+            {
+                return -1;
+            }
+
+            for (int i = path.Length - 1; i >= 0; i--)
+            {
+                char ch = path[i];
+                if (ch == DirectorySeparatorChar || ch == AltDirectorySeparatorChar || ch == VolumeSeparatorChar)
+                {
+                    return i + 1;
+                }
+            }
+
+            return 0;
+        }
+
+        internal static bool IsDirectorySeparator(char separator)
+        {
+            return separator == DirectorySeparatorChar || separator == AltDirectorySeparatorChar;
+        }
+
+        internal static string GetFileName(string path)
+        {
+            int fileNameStart = IndexOfFileName(path);
+            return (fileNameStart <= 0) ? path : path.Substring(fileNameStart);
+        }
+
+        internal static string GetDirectoryName(string path)
+        {
+            int fileNameStart = IndexOfFileName(path);
+            while (fileNameStart >= 0
+                && IsDirectorySeparator(path[fileNameStart - 1]))
+            {
+                fileNameStart--;
+            }
+
+            return (fileNameStart <= 0) ? path : path.Substring(0, fileNameStart);
+        }
+
+        internal static string TrimStartDirectorySeparators(string path)
+        {
+            var i = 0;
+            while (IsDirectorySeparator(path[i]))
+            {
+                i++;
+            }
+
+            return i == 0 ? path : path.Substring(i);
+        }
+    }
+}

--- a/src/bctklib-3/FileNameUtilities.cs
+++ b/src/bctklib-3/FileNameUtilities.cs
@@ -1,5 +1,10 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root of https://github.com/dotnet/symreader-portable for license information.
+
 namespace Neo.BlockchainToolkit
 {
+    // This Library contains logic that need to handle both Windows and Unix style paths. For example, debug info can be created on Windows and read
+    // on Mac/Linux or vis versa. So the standard Path.GetFileName/GetDirectoryName method will not work.
+
     // This logic lifted from https://github.com/dotnet/symreader-portable/blob/main/src/Microsoft.DiaSymReader.PortablePdb/Utilities/FileNameUtilities.cs
     internal static class FileNameUtilities
     {

--- a/src/bctklib-3/models/DebugInfo.cs
+++ b/src/bctklib-3/models/DebugInfo.cs
@@ -120,7 +120,8 @@ namespace Neo.BlockchainToolkit.Models
                 {
                     if (_document.StartsWith(kvp.Key))
                     {
-                        var mapDocument = fileSystem.Path.Join(kvp.Value, _document.Substring(kvp.Key.Length));
+                        var remainder = FileNameUtilities.TrimStartDirectorySeparators(_document.Substring(kvp.Key.Length));
+                        var mapDocument = fileSystem.NormalizePath(fileSystem.Path.Join(kvp.Value, remainder));
                         if (fileSystem.File.Exists(mapDocument))
                         {
                             return mapDocument;
@@ -129,10 +130,10 @@ namespace Neo.BlockchainToolkit.Models
                 }
 
                 var cwd = fileSystem.Directory.GetCurrentDirectory();
-                var cwdDocument = fileSystem.Path.Join(cwd, fileSystem.Path.GetFileName(_document));
+                var cwdDocument = fileSystem.Path.Join(cwd, FileNameUtilities.GetFileName(_document));
                 if (fileSystem.File.Exists(cwdDocument))
                 {
-                    var directoryName = fileSystem.Path.GetDirectoryName(_document);
+                    var directoryName = FileNameUtilities.GetDirectoryName(_document);
                     if (directoryName != null)
                     {
                         folderMap.Add(directoryName, cwd);
@@ -141,7 +142,7 @@ namespace Neo.BlockchainToolkit.Models
                     return cwdDocument;
                 }
 
-                var folderName = fileSystem.Path.GetFileName(cwd);
+                var folderName = FileNameUtilities.GetFileName(cwd);
                 var folderIndex = _document.IndexOf(folderName);
                 if (folderIndex >= 0)
                 {

--- a/test/test.bctklib-3/ContractParameterParserTest.cs
+++ b/test/test.bctklib-3/ContractParameterParserTest.cs
@@ -211,12 +211,11 @@ namespace test.bctklib3
             var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
             var exception = Assert.Throws<FileNotFoundException>(() => parser.ParseStringParameter($"file://{someFakePathFile}"));
 
-            // only check file name due to forward/back slash changes
-            Assert.Equal(Path.GetFileName(someFakePathFile), Path.GetFileName(exception.FileName));
+            Assert.Equal(someFakePathFile, exception.FileName);
         }
 
         [Fact]
-        public void TestParseStringParameter_file_uri_relative()
+        public void TestParseStringParameter_file_uri_relative_current_directory_unix()
         {
             var fileSystem = new MockFileSystem();
             var rootPath = fileSystem.AllDirectories.First();
@@ -233,7 +232,7 @@ namespace test.bctklib3
         }
 
         [Fact]
-        public void TestParseStringParameter_file_uri_relative_windows()
+        public void TestParseStringParameter_file_uri_relative_current_directory_windows()
         {
             var fileSystem = new MockFileSystem();
             var rootPath = fileSystem.AllDirectories.First();
@@ -250,7 +249,7 @@ namespace test.bctklib3
         }
 
         [Fact]
-        public void TestParseStringParameter_file_uri_relative_2_unix()
+        public void TestParseStringParameter_file_uri_relative_subdirectory_unix()
         {
             var fileSystem = new MockFileSystem();
             var rootPath = fileSystem.AllDirectories.First();
@@ -266,7 +265,7 @@ namespace test.bctklib3
         }
 
         [Fact]
-        public void TestParseStringParameter_file_uri_relative_2_windows()
+        public void TestParseStringParameter_file_uri_relative_subdirectory_windows()
         {
             var fileSystem = new MockFileSystem();
             var rootPath = fileSystem.AllDirectories.First();
@@ -282,7 +281,7 @@ namespace test.bctklib3
         }
 
         [Fact]
-        public void TestParseStringParameter_file_uri_relative_3()
+        public void TestParseStringParameter_file_uri_relative_parent_directory_unix()
         {
             var fileSystem = new MockFileSystem();
             var rootPath = fileSystem.AllDirectories.First();
@@ -299,7 +298,7 @@ namespace test.bctklib3
         }
 
         [Fact]
-        public void TestParseStringParameter_file_uri_relative_3_windows()
+        public void TestParseStringParameter_file_uri_relative_parent_directory_windows()
         {
             var fileSystem = new MockFileSystem();
             var rootPath = fileSystem.AllDirectories.First();

--- a/test/test.bctklib-3/ContractParameterParserTest.cs
+++ b/test/test.bctklib-3/ContractParameterParserTest.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
 using System.Runtime.InteropServices;
 using FluentAssertions;
 using Neo;
@@ -187,47 +188,92 @@ namespace test.bctklib3
         [Fact]
         public void TestParseStringParameter_file_uri()
         {
-            const string PATH = @"c:\some\fake\path\file.txt";
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var someFakePathFile = fileSystem.Path.Combine(rootPath, "some", "fake", "path", "file.txt");
             var mockFile = new MockFileData("2a333738-c897-45db-ac76-67b66deb4c1f");
-
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                { PATH, mockFile },
-            });
+            fileSystem.AddFile(someFakePathFile, mockFile);
 
             var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
-            var param = parser.ParseStringParameter($"file://{PATH}");
+            var param = parser.ParseStringParameter($"file://{someFakePathFile}");
             param.Type.Should().Be(ContractParameterType.ByteArray);
             param.Value.Should().BeEquivalentTo(mockFile.Contents);
+        }
+
+        [Fact]
+        public void TestParseStringParameter_file_uri_not_found()
+        {
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var someFakePathFile = fileSystem.Path.Combine(rootPath, "some", "fake", "path", "file.txt");
+            var mockFile = new MockFileData("2a333738-c897-45db-ac76-67b66deb4c1f");
+
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
+            var exception = Assert.Throws<FileNotFoundException>(() => parser.ParseStringParameter($"file://{someFakePathFile}"));
+
+            // only check file name due to forward/back slash changes
+            Assert.Equal(Path.GetFileName(someFakePathFile), Path.GetFileName(exception.FileName));
         }
 
         [Fact]
         public void TestParseStringParameter_file_uri_relative()
         {
-            const string PATH = @"c:\some\fake\path\file.txt";
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var someFakePath = fileSystem.Path.Combine(rootPath, "some", "fake", "path");
+            fileSystem.Directory.SetCurrentDirectory(someFakePath);
             var mockFile = new MockFileData("2a333738-c897-45db-ac76-67b66deb4c1f");
-
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                { PATH, mockFile },
-            }, @"c:\some\fake\path\");
+            fileSystem.AddFile(fileSystem.Path.Combine(someFakePath, "file.txt"), mockFile);
 
             var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
             var param = parser.ParseStringParameter($"file://./file.txt");
+
             param.Type.Should().Be(ContractParameterType.ByteArray);
             param.Value.Should().BeEquivalentTo(mockFile.Contents);
         }
 
         [Fact]
-        public void TestParseStringParameter_file_uri_relative_2()
+        public void TestParseStringParameter_file_uri_relative_windows()
         {
-            const string PATH = @"c:\some\fake\path\file.txt";
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var someFakePath = fileSystem.Path.Combine(rootPath, "some", "fake", "path");
+            fileSystem.Directory.SetCurrentDirectory(someFakePath);
             var mockFile = new MockFileData("2a333738-c897-45db-ac76-67b66deb4c1f");
+            fileSystem.AddFile(fileSystem.Path.Combine(someFakePath, "file.txt"), mockFile);
 
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                { PATH, mockFile },
-            }, @"c:\some\fake\");
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
+            var param = parser.ParseStringParameter($"file://.\\file.txt");
+
+            param.Type.Should().Be(ContractParameterType.ByteArray);
+            param.Value.Should().BeEquivalentTo(mockFile.Contents);
+        }
+
+        [Fact]
+        public void TestParseStringParameter_file_uri_relative_2_unix()
+        {
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var someFakePath = fileSystem.Path.Combine(rootPath, "some", "fake", "path");
+            fileSystem.Directory.SetCurrentDirectory(fileSystem.Path.GetDirectoryName(someFakePath));
+            var mockFile = new MockFileData("2a333738-c897-45db-ac76-67b66deb4c1f");
+            fileSystem.AddFile(fileSystem.Path.Combine(someFakePath, "file.txt"), mockFile);
+
+            var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
+            var param = parser.ParseStringParameter($"file://./path/file.txt");
+            param.Type.Should().Be(ContractParameterType.ByteArray);
+            param.Value.Should().BeEquivalentTo(mockFile.Contents);
+        }
+
+        [Fact]
+        public void TestParseStringParameter_file_uri_relative_2_windows()
+        {
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var someFakePath = fileSystem.Path.Combine(rootPath, "some", "fake", "path");
+            fileSystem.Directory.SetCurrentDirectory(fileSystem.Path.GetDirectoryName(someFakePath));
+            var mockFile = new MockFileData("2a333738-c897-45db-ac76-67b66deb4c1f");
+            fileSystem.AddFile(fileSystem.Path.Combine(someFakePath, "file.txt"), mockFile);
 
             var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
             var param = parser.ParseStringParameter($"file://.\\path\\file.txt");
@@ -238,31 +284,35 @@ namespace test.bctklib3
         [Fact]
         public void TestParseStringParameter_file_uri_relative_3()
         {
-            const string PATH = @"c:\some\fake\path\file.txt";
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var someFakePath = fileSystem.Path.Combine(rootPath, "some", "fake", "path");
+            fileSystem.Directory.SetCurrentDirectory(fileSystem.Path.Combine(someFakePath, "test"));
             var mockFile = new MockFileData("2a333738-c897-45db-ac76-67b66deb4c1f");
-
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                { PATH, mockFile },
-            }, @"c:\some\fake\path\test");
+            fileSystem.AddFile(fileSystem.Path.Combine(someFakePath, "file.txt"), mockFile);
 
             var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
-            var param = parser.ParseStringParameter($"file://..\\file.txt");
+            var param = parser.ParseStringParameter($"file://../file.txt");
+
             param.Type.Should().Be(ContractParameterType.ByteArray);
             param.Value.Should().BeEquivalentTo(mockFile.Contents);
         }
 
         [Fact]
-        public void TestParseStringParameter_file_uri_not_found()
+        public void TestParseStringParameter_file_uri_relative_3_windows()
         {
-            const string PATH = @"c:\some\fake\path\file.txt";
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { });
+            var fileSystem = new MockFileSystem();
+            var rootPath = fileSystem.AllDirectories.First();
+            var someFakePath = fileSystem.Path.Combine(rootPath, "some", "fake", "path");
+            fileSystem.Directory.SetCurrentDirectory(fileSystem.Path.Combine(someFakePath, "test"));
+            var mockFile = new MockFileData("2a333738-c897-45db-ac76-67b66deb4c1f");
+            fileSystem.AddFile(fileSystem.Path.Combine(someFakePath, "file.txt"), mockFile);
 
             var parser = new ContractParameterParser(DEFAULT_ADDRESS_VERSION, fileSystem: fileSystem);
-            var exception = Assert.Throws<FileNotFoundException>(() => parser.ParseStringParameter($"file://{PATH}"));
+            var param = parser.ParseStringParameter($"file://..\\file.txt");
 
-            // only check file name due to forward/back slash changes
-            Assert.Equal(Path.GetFileName(PATH), Path.GetFileName(exception.FileName));
+            param.Type.Should().Be(ContractParameterType.ByteArray);
+            param.Value.Should().BeEquivalentTo(mockFile.Contents);
         }
     }
 }

--- a/test/test.bctklib-3/DebugInfoTest.cs
+++ b/test/test.bctklib-3/DebugInfoTest.cs
@@ -11,7 +11,6 @@ using Neo.BlockchainToolkit.Models;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-
 namespace test.bctklib3
 {
     public class DebugInfoTest

--- a/test/test.bctklib-3/ExpressChainTest.cs
+++ b/test/test.bctklib-3/ExpressChainTest.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
 using System.Text.Json;
 using FluentAssertions;
 using Neo;
@@ -10,7 +11,7 @@ namespace test.bctklib3
 {
     public class ExpressChainTest
     {
-        const string FILENAME = "c:/default.neo-express";
+        const string FILENAME = "default.neo-express";
         const string TEST_SETTING = "test.setting";
         const string TEST_SETTING_VALUE = "some value";
 
@@ -18,6 +19,7 @@ namespace test.bctklib3
         public void missing_address_version_defaults_correctly()
         {
             var fileSystem = new MockFileSystem();
+            var drives = fileSystem.DriveInfo.GetDrives();
             fileSystem.AddFile(FILENAME, new MockFileData("{'magic': 1218031260}"));
 
             var chain = fileSystem.LoadChain(FILENAME);
@@ -30,9 +32,10 @@ namespace test.bctklib3
             const byte addressVersion = 0x53;
 
             var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(FILENAME, new MockFileData($"{{'magic': 1218031260, 'address-version': {addressVersion} }}"));
+            var fileName = fileSystem.Path.Combine(fileSystem.AllDirectories.First(), FILENAME);
+            fileSystem.AddFile(fileName, new MockFileData($"{{'magic': 1218031260, 'address-version': {addressVersion} }}"));
 
-            var chain = fileSystem.LoadChain(FILENAME);
+            var chain = fileSystem.LoadChain(fileName);
             chain.AddressVersion.Should().Be(addressVersion);
         }
 
@@ -40,9 +43,10 @@ namespace test.bctklib3
         public void settings_default_to_empty_dictionary()
         {
             var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(FILENAME, new MockFileData($"{{ }}"));
+            var fileName = fileSystem.Path.Combine(fileSystem.AllDirectories.First(), FILENAME);
+            fileSystem.AddFile(fileName, new MockFileData($"{{ }}"));
 
-            var chain = fileSystem.LoadChain(FILENAME);
+            var chain = fileSystem.LoadChain(fileName);
             chain.Settings.Should().BeEmpty();
         }
 
@@ -50,10 +54,11 @@ namespace test.bctklib3
         public void empty_settings_save_correctly()
         {
             var fileSystem = new MockFileSystem();
+            var fileName = fileSystem.Path.Combine(fileSystem.AllDirectories.First(), FILENAME);
             var chain = new ExpressChain();
-            fileSystem.SaveChain(chain, FILENAME);
+            fileSystem.SaveChain(chain, fileName);
 
-            using var json = JsonDocument.Parse(fileSystem.GetFile(FILENAME).Contents);
+            using var json = JsonDocument.Parse(fileSystem.GetFile(fileName).Contents);
             var settings = json.RootElement.GetProperty("settings");
             settings.EnumerateObject().Should().BeEmpty();
         }
@@ -62,11 +67,12 @@ namespace test.bctklib3
         public void settings_save_correctly()
         {
             var fileSystem = new MockFileSystem();
+            var fileName = fileSystem.Path.Combine(fileSystem.AllDirectories.First(), FILENAME);
             var chain = new ExpressChain();
             chain.Settings.Add(TEST_SETTING, TEST_SETTING_VALUE);
-            fileSystem.SaveChain(chain, FILENAME);
+            fileSystem.SaveChain(chain, fileName);
 
-            using var json = JsonDocument.Parse(fileSystem.GetFile(FILENAME).Contents);
+            using var json = JsonDocument.Parse(fileSystem.GetFile(fileName).Contents);
             var settings = json.RootElement.GetProperty("settings");
             settings.EnumerateObject().Should().NotBeEmpty();
             settings.GetProperty(TEST_SETTING).GetString().Should().Be(TEST_SETTING_VALUE);
@@ -76,9 +82,10 @@ namespace test.bctklib3
         public void settings_load_correctly()
         {
             var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(FILENAME, new MockFileData($"{{'settings': {{ '{TEST_SETTING}': '{TEST_SETTING_VALUE}' }} }}"));
+            var fileName = fileSystem.Path.Combine(fileSystem.AllDirectories.First(), FILENAME);
+            fileSystem.AddFile(fileName, new MockFileData($"{{'settings': {{ '{TEST_SETTING}': '{TEST_SETTING_VALUE}' }} }}"));
 
-            var chain = fileSystem.LoadChain(FILENAME);
+            var chain = fileSystem.LoadChain(fileName);
 
             chain.Settings.Should().Contain(TEST_SETTING, TEST_SETTING_VALUE);
         }

--- a/test/test.bctklib-3/ExpressChainTest.cs
+++ b/test/test.bctklib-3/ExpressChainTest.cs
@@ -19,8 +19,8 @@ namespace test.bctklib3
         public void missing_address_version_defaults_correctly()
         {
             var fileSystem = new MockFileSystem();
-            var drives = fileSystem.DriveInfo.GetDrives();
-            fileSystem.AddFile(FILENAME, new MockFileData("{'magic': 1218031260}"));
+            var fileName = fileSystem.Path.Combine(fileSystem.AllDirectories.First(), FILENAME);
+            fileSystem.AddFile(fileName, new MockFileData("{'magic': 1218031260}"));
 
             var chain = fileSystem.LoadChain(FILENAME);
             chain.AddressVersion.Should().Be(ProtocolSettings.Default.AddressVersion);


### PR DESCRIPTION
This PR updates DebugInfo + ContractParameterParser to support cross platform path parsing. It's possible to generate debug info or invoke files on one platform and use them on another. So this library can't depend on BCL Path.GetFileName/GetDirectoryName methods. Instead, it uses a FileNameUtilities class derived from the Portable PDB reader project to parse path names independently of the current platform.

This PR also updates the azure CI script to run tests on both Windows and Ubuntu before packing and publishing the package to Azure Artifacts

fixes #30