### PR TITLE
Update TraceDebug Models

### DIFF
--- a/src/bctklib-3/trace-models/FaultRecord.cs
+++ b/src/bctklib-3/trace-models/FaultRecord.cs
@@ -19,12 +19,16 @@ namespace Neo.BlockchainToolkit.TraceDebug
         public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, string exception)
         {
             var mpWriter = new MessagePackWriter(writer);
-            mpWriter.WriteArrayHeader(2);
-            mpWriter.WriteInt32(RecordKey);
-            mpWriter.WriteArrayHeader(1);
-            options.Resolver.GetFormatterWithVerify<string>().Serialize(ref mpWriter, exception, options);
+            Write(ref mpWriter, options, exception);
             mpWriter.Flush();
         }
 
+        public static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, string exception)
+        {
+            writer.WriteArrayHeader(2);
+            writer.WriteInt32(RecordKey);
+            writer.WriteArrayHeader(1);
+            options.Resolver.GetFormatterWithVerify<string>().Serialize(ref writer, exception, options);
+        }
     }
 }

--- a/src/bctklib-3/trace-models/Formatters/ScriptFormatter.cs
+++ b/src/bctklib-3/trace-models/Formatters/ScriptFormatter.cs
@@ -1,5 +1,3 @@
-using System.Buffers;
-using Neo.Ledger;
 using Neo.VM;
 
 namespace MessagePack.Formatters.Neo.BlockchainToolkit.TraceDebug
@@ -15,7 +13,7 @@ namespace MessagePack.Formatters.Neo.BlockchainToolkit.TraceDebug
 
         public void Serialize(ref MessagePackWriter writer, Script value, MessagePackSerializerOptions options)
         {
-            options.Resolver.GetFormatter<byte[]>().Serialize(ref writer, value, options);
+            writer.Write((byte[])value);
         }
     }
 }

--- a/src/bctklib-3/trace-models/Formatters/StorageItemFormatter.cs
+++ b/src/bctklib-3/trace-models/Formatters/StorageItemFormatter.cs
@@ -9,18 +9,18 @@ namespace MessagePack.Formatters.Neo.BlockchainToolkit.TraceDebug
 
         public StorageItem Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            if (reader.ReadArrayHeader() != 1)
+            if (reader.NextMessagePackType == MessagePackType.Array)
             {
-                throw new MessagePackSerializationException();
+                var count = reader.ReadArrayHeader();
+                if (count != 1) throw new MessagePackSerializationException($"Invalid StorageItem Array Header {count}");
             }
 
-            var value = reader.ReadBytes()?.ToArray() ?? throw new MessagePackSerializationException();
+            var value = options.Resolver.GetFormatter<byte[]>().Deserialize(ref reader, options);
             return new StorageItem(value);
         }
 
         public void Serialize(ref MessagePackWriter writer, StorageItem value, MessagePackSerializerOptions options)
         {
-            writer.WriteArrayHeader(1);
             writer.Write(value.Value);
         }
     }

--- a/src/bctklib-3/trace-models/Formatters/TraceDebugResolver.cs
+++ b/src/bctklib-3/trace-models/Formatters/TraceDebugResolver.cs
@@ -11,6 +11,7 @@ namespace MessagePack.Resolvers
                 ScriptFormatter.Instance,
                 StackItemFormatter.Instance,
                 StorageItemFormatter.Instance,
+                TraceRecordFormatter.Instance,
                 UInt160Formatter.Instance
             },
             new IFormatterResolver[]

--- a/src/bctklib-3/trace-models/Formatters/TraceRecordFormatter.cs
+++ b/src/bctklib-3/trace-models/Formatters/TraceRecordFormatter.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Neo.BlockchainToolkit.TraceDebug;
+using VMState = Neo.VM.VMState;
+
+namespace MessagePack.Formatters.Neo.BlockchainToolkit.TraceDebug
+{
+    public class TraceRecordFormatter : IMessagePackFormatter<TraceRecord>
+    {
+        public static readonly TraceRecordFormatter Instance = new TraceRecordFormatter();
+
+        public TraceRecord Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            // Older trace records (N3 RC3 and before) did not have gas consumed value.
+            // When parsing TraceRecords, if there are only two fields in the TraceRecord array, provide a dummy gasConsumed value.
+
+            var fieldCount = reader.ReadArrayHeader();
+            if (fieldCount != 2 && fieldCount != 3) throw new MessagePackSerializationException($"Invalid TraceRecord Array Header {fieldCount}");
+
+            var state = options.Resolver.GetFormatterWithVerify<VMState>().Deserialize(ref reader, options);
+            var gasConsumed = fieldCount == 3 ? reader.ReadInt64() : 0;
+            var stackFrames = options.Resolver.GetFormatterWithVerify<IReadOnlyList<TraceRecord.StackFrame>>().Deserialize(ref reader, options);
+
+            return new TraceRecord(state, gasConsumed, stackFrames);
+        }
+
+        public void Serialize(ref MessagePackWriter writer, TraceRecord value, MessagePackSerializerOptions options)
+        {
+            writer.WriteArrayHeader(3);
+            options.Resolver.GetFormatterWithVerify<VMState>().Serialize(ref writer, value.State, options);
+            writer.WriteInt64(value.GasConsumed);
+            options.Resolver.GetFormatterWithVerify<IReadOnlyList<TraceRecord.StackFrame>>().Serialize(ref writer, value.StackFrames, options);
+        }
+    }
+}

--- a/src/bctklib-3/trace-models/LogRecord.cs
+++ b/src/bctklib-3/trace-models/LogRecord.cs
@@ -25,13 +25,21 @@ namespace Neo.BlockchainToolkit.TraceDebug
         public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, UInt160 scriptHash, string scriptName, string message)
         {
             var mpWriter = new MessagePackWriter(writer);
-            mpWriter.WriteArrayHeader(2);
-            mpWriter.WriteInt32(RecordKey);
-            mpWriter.WriteArrayHeader(3);
-            options.Resolver.GetFormatterWithVerify<Neo.UInt160>().Serialize(ref mpWriter, scriptHash, options);
-            options.Resolver.GetFormatterWithVerify<string>().Serialize(ref mpWriter, scriptName, options);
-            options.Resolver.GetFormatterWithVerify<string>().Serialize(ref mpWriter, message, options);
+            Write(ref mpWriter, options, scriptHash, scriptName, message);
             mpWriter.Flush();
+        }
+
+        public static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, UInt160 scriptHash, string scriptName, string message)
+        {
+            var stringFormatter = options.Resolver.GetFormatterWithVerify<string>();
+
+            writer.WriteArrayHeader(2);
+            writer.WriteInt32(RecordKey);
+            writer.WriteArrayHeader(3);
+            options.Resolver.GetFormatterWithVerify<Neo.UInt160>().Serialize(ref writer, scriptHash, options);
+            stringFormatter.Serialize(ref writer, scriptName, options);
+            stringFormatter.Serialize(ref writer, message, options);
+            writer.Flush();
         }
     }
 }

--- a/src/bctklib-3/trace-models/NotifyRecord.cs
+++ b/src/bctklib-3/trace-models/NotifyRecord.cs
@@ -44,5 +44,24 @@ namespace Neo.BlockchainToolkit.TraceDebug
             }
             mpWriter.Flush();
         }
+
+        public static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, UInt160 scriptHash, string scriptName, string eventName, IReadOnlyCollection<StackItem> state)
+        {
+            var stackItemFormatter = options.Resolver.GetFormatterWithVerify<StackItem>();
+            var stringFormatter = options.Resolver.GetFormatterWithVerify<string>();
+
+            writer.WriteArrayHeader(2);
+            writer.WriteInt32(RecordKey);
+            writer.WriteArrayHeader(4);
+            options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref writer, scriptHash, options);
+            stringFormatter.Serialize(ref writer, scriptName, options);
+            stringFormatter.Serialize(ref writer, eventName, options);
+            writer.WriteArrayHeader(state.Count);
+            foreach (var item in state)
+            {
+                stackItemFormatter.Serialize(ref writer, item, options);
+            }
+            writer.Flush();
+        }
     }
 }

--- a/src/bctklib-3/trace-models/ProtocolSettingsRecord.cs
+++ b/src/bctklib-3/trace-models/ProtocolSettingsRecord.cs
@@ -23,12 +23,17 @@ namespace Neo.BlockchainToolkit.TraceDebug
         public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, uint network, byte addressVersion)
         {
             var mpWriter = new MessagePackWriter(writer);
-            mpWriter.WriteArrayHeader(2);
-            mpWriter.WriteInt32(RecordKey);
-            mpWriter.WriteArrayHeader(2);
-            options.Resolver.GetFormatterWithVerify<uint>().Serialize(ref mpWriter, network, options);
-            options.Resolver.GetFormatterWithVerify<byte>().Serialize(ref mpWriter, addressVersion, options);
+            Write(ref mpWriter, options, network, addressVersion);
             mpWriter.Flush();
+        }
+
+        public static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, uint network, byte addressVersion)
+        {
+            writer.WriteArrayHeader(2);
+            writer.WriteInt32(RecordKey);
+            writer.WriteArrayHeader(2);
+            writer.WriteUInt32(network);
+            writer.Write(addressVersion);
         }
     }
 }

--- a/src/bctklib-3/trace-models/ResultsRecord.cs
+++ b/src/bctklib-3/trace-models/ResultsRecord.cs
@@ -28,18 +28,18 @@ namespace Neo.BlockchainToolkit.TraceDebug
         public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, VMState vmState, long gasConsumed, IReadOnlyCollection<StackItem> resultStack)
         {
             var mpWriter = new MessagePackWriter(writer);
-            mpWriter.WriteArrayHeader(2);
-            mpWriter.WriteInt32(RecordKey);
-            mpWriter.WriteArrayHeader(3);
-            options.Resolver.GetFormatterWithVerify<VMState>().Serialize(ref mpWriter, vmState, options);
-            mpWriter.Write(gasConsumed);
-            mpWriter.WriteArrayHeader(resultStack.Count);
-            foreach (var item in resultStack)
-            {
-                options.Resolver.GetFormatterWithVerify<StackItem>().Serialize(ref mpWriter, item, options);
-            }
+            Write(ref mpWriter, options, vmState, gasConsumed, resultStack);
             mpWriter.Flush();
         }
 
+        public static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, VMState vmState, long gasConsumed, IReadOnlyCollection<StackItem> resultStack)
+        {
+            writer.WriteArrayHeader(2);
+            writer.WriteInt32(RecordKey);
+            writer.WriteArrayHeader(3);
+            options.Resolver.GetFormatterWithVerify<VMState>().Serialize(ref writer, vmState, options);
+            writer.Write(gasConsumed);
+            options.Resolver.GetFormatterWithVerify<IReadOnlyCollection<StackItem>>().Serialize(ref writer, resultStack, options);
+        }
     }
 }

--- a/src/bctklib-3/trace-models/ScriptRecord.cs
+++ b/src/bctklib-3/trace-models/ScriptRecord.cs
@@ -23,15 +23,21 @@ namespace Neo.BlockchainToolkit.TraceDebug
 
         public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, byte[] script)
         {
+            var mpWriter = new MessagePackWriter(writer);
+            Write(ref mpWriter, options, script);
+            mpWriter.Flush();
+        }
+
+        public static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, byte[] script)
+        {
             var scriptHash = Neo.SmartContract.Helper.ToScriptHash(script);
 
-            var mpWriter = new MessagePackWriter(writer);
-            mpWriter.WriteArrayHeader(2);
-            mpWriter.WriteInt32(RecordKey);
-            mpWriter.WriteArrayHeader(2);
-            options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref mpWriter, scriptHash, options);
-            options.Resolver.GetFormatterWithVerify<byte[]>().Serialize(ref mpWriter, script, options);
-            mpWriter.Flush();
+            writer.WriteArrayHeader(2);
+            writer.WriteInt32(RecordKey);
+            writer.WriteArrayHeader(2);
+            options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref writer, scriptHash, options);
+            options.Resolver.GetFormatterWithVerify<Script>().Serialize(ref writer, script, options);
+            writer.Flush();
         }
     }
 }

--- a/src/bctklib-3/trace-models/TraceRecord.StackFrame.cs
+++ b/src/bctklib-3/trace-models/TraceRecord.StackFrame.cs
@@ -15,16 +15,16 @@ namespace Neo.BlockchainToolkit.TraceDebug
         // However, debugging requires the SHA 256 hash of the script binary to tie a specific contract version to its associated debug info.
 
         // In TraceRecord:
-        //   * ScriptIdentifier property is the UInt160 value created on script deployment that identifies a contract (even after updates)
-        //   * ScriptHash is the SHA 256 hash of the script binary, needed to map scripts to debug info
+        //   * ScriptHash property is the UInt160 value created on script deployment that identifies a contract (even after updates)
+        //   * ScriptIdentifier is the SHA 256 hash of the script binary, needed to map scripts to debug info
 
         [MessagePackObject]
         public class StackFrame
         {
             [Key(0)]
-            public readonly UInt160 ScriptIdentifier;
-            [Key(1)]
             public readonly UInt160 ScriptHash;
+            [Key(1)]
+            public readonly UInt160 ScriptIdentifier;
             [Key(2)]
             public readonly int InstructionPointer;
             [Key(3)]
@@ -39,8 +39,8 @@ namespace Neo.BlockchainToolkit.TraceDebug
             public readonly IReadOnlyList<StackItem> Arguments;
 
             public StackFrame(
-                UInt160 scriptIdentifier,
                 UInt160 scriptHash,
+                UInt160 scriptIdentifier,
                 int instructionPointer,
                 bool hasCatch,
                 IReadOnlyList<StackItem> evaluationStack,
@@ -48,8 +48,8 @@ namespace Neo.BlockchainToolkit.TraceDebug
                 IReadOnlyList<StackItem> staticFields,
                 IReadOnlyList<StackItem> arguments)
             {
-                ScriptIdentifier = scriptIdentifier;
                 ScriptHash = scriptHash;
+                ScriptIdentifier = scriptIdentifier;
                 InstructionPointer = instructionPointer;
                 HasCatch = hasCatch;
                 EvaluationStack = evaluationStack;
@@ -58,28 +58,22 @@ namespace Neo.BlockchainToolkit.TraceDebug
                 Arguments = arguments;
             }
 
-            internal static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, IDictionary<UInt160, UInt160> scriptIdMap, ExecutionContext context)
+            internal static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, ExecutionContext context, UInt160 scriptIdentifier)
             {
-                var scriptId = context.GetScriptHash();
-                if (!scriptIdMap.TryGetValue(scriptId, out var scriptHash))
-                {
-                    scriptHash = Neo.SmartContract.Helper.ToScriptHash(context.Script);
-                    scriptIdMap[scriptId] = scriptHash;
-                }
-
-                var stackItemCollectionResolver = options.Resolver.GetFormatterWithVerify<IReadOnlyCollection<StackItem>>();
+                var uint160Formatter = options.Resolver.GetFormatterWithVerify<UInt160>();
+                var stackItemCollectionFormatter = options.Resolver.GetFormatterWithVerify<IReadOnlyCollection<StackItem>>();
 
                 writer.WriteArrayHeader(8);
-                options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref writer, scriptId, options);
-                options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref writer, scriptHash, options);
+                uint160Formatter.Serialize(ref writer, context.GetScriptHash(), options);
+                uint160Formatter.Serialize(ref writer, scriptIdentifier, options);
                 writer.Write(context.InstructionPointer);
                 writer.Write(context.TryStack?.Any(c => c.HasCatch) == true);
-                stackItemCollectionResolver.Serialize(ref writer, context.EvaluationStack, options);
-                stackItemCollectionResolver.Serialize(ref writer, Coalese(context.LocalVariables), options);
-                stackItemCollectionResolver.Serialize(ref writer, Coalese(context.StaticFields), options);
-                stackItemCollectionResolver.Serialize(ref writer, Coalese(context.Arguments), options);
+                stackItemCollectionFormatter.Serialize(ref writer, context.EvaluationStack, options);
+                stackItemCollectionFormatter.Serialize(ref writer, Coalese(context.LocalVariables), options);
+                stackItemCollectionFormatter.Serialize(ref writer, Coalese(context.StaticFields), options);
+                stackItemCollectionFormatter.Serialize(ref writer, Coalese(context.Arguments), options);
 
-                static IReadOnlyList<StackItem> Coalese(Neo.VM.Slot? slot) => (slot == null) ? Array.Empty<StackItem>() : slot;
+                static IReadOnlyCollection<StackItem> Coalese(Neo.VM.Slot? slot) => (slot == null) ? Array.Empty<StackItem>() : slot;
             }
         }
     }

--- a/test/test.bctklib-3/TraceDebugTests.cs
+++ b/test/test.bctklib-3/TraceDebugTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using MessagePack;
+using MessagePack.Resolvers;
+using Neo;
+using Neo.BlockchainToolkit.TraceDebug;
+using Neo.IO;
+using Neo.SmartContract;
+using Neo.VM;
+using Nerdbank.Streams;
+using Xunit;
+
+namespace test.bctklib3
+{
+    public class TraceDebugTests
+    {
+        MessagePackSerializerOptions options = MessagePackSerializerOptions.Standard.WithResolver(TraceDebugResolver.Instance);
+
+        [Fact]
+        public void can_deserialize_trace_record_with_no_gas()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            TraceRecord_WriteWithoutGas(writer, options, VMState.BREAK, Array.Empty<ExecutionContext>(), _ => UInt160.Zero);
+
+            var record = MessagePackSerializer.Deserialize<ITraceDebugRecord>(writer.WrittenMemory, options);
+
+            Assert.IsType<TraceRecord>(record);
+            if (record is TraceRecord traceRecord)
+            {
+                Assert.Equal(VMState.BREAK, traceRecord.State);
+                Assert.Equal(0, traceRecord.GasConsumed);
+            }
+        }
+
+        static void TraceRecord_WriteWithoutGas(
+           IBufferWriter<byte> writer, MessagePackSerializerOptions options, VMState vmState,
+           IReadOnlyCollection<ExecutionContext> contexts, Func<ExecutionContext, UInt160> getScriptIdentifier)
+        {
+            var mpWriter = new MessagePackWriter(writer);
+            mpWriter.WriteArrayHeader(2);
+            mpWriter.WriteInt32(TraceRecord.RecordKey);
+            mpWriter.WriteArrayHeader(2);
+            options.Resolver.GetFormatterWithVerify<VMState>().Serialize(ref mpWriter, vmState, options);
+            mpWriter.WriteArrayHeader(contexts.Count);
+            foreach (var context in contexts)
+            {
+                TraceRecord.StackFrame.Write(ref mpWriter, options, context, getScriptIdentifier(context));
+            }
+            mpWriter.Flush();
+        }
+
+        [Fact]
+        public void can_deserialize_trace_record_with_gas()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            TraceRecord.Write(writer, options, VMState.BREAK, 1000, Array.Empty<ExecutionContext>(), _ => UInt160.Zero);
+
+            var record = MessagePackSerializer.Deserialize<ITraceDebugRecord>(writer.WrittenMemory, options);
+
+            Assert.IsType<TraceRecord>(record);
+            if (record is TraceRecord traceRecord)
+            {
+                Assert.Equal(VMState.BREAK, traceRecord.State);
+                Assert.Equal(1000, traceRecord.GasConsumed);
+            }
+        }
+
+        [Fact]
+        public void can_deserialize_storage_record_with_array_header()
+        {
+            var scriptHash = UInt160.Parse("0001020304050607080900010203040506070809");
+            var storages = new[] {
+                (key: new StorageKey { Key = Convert.FromHexString("01")}, value: new StorageItem(Convert.FromHexString("11121314"))),
+                (key: new StorageKey { Key = Convert.FromHexString("02")}, value: new StorageItem(Convert.FromHexString("21222324")))
+            };
+
+            var writer = new ArrayBufferWriter<byte>();
+            StorageRecord_WriteWithStorageItemArrayHeader(writer, options, scriptHash, storages);
+
+            var record = MessagePackSerializer.Deserialize<ITraceDebugRecord>(writer.WrittenMemory, options);
+
+            Assert.IsType<StorageRecord>(record);
+            if (record is StorageRecord storageRecord)
+            {
+                Assert.Equal(scriptHash, storageRecord.ScriptHash);
+                Assert.Equal(storages.Length, storageRecord.Storages.Count);
+            }
+        }
+
+        [Fact]
+        public void can_deserialize_storage_record_without_array_header()
+        {
+            var scriptHash = UInt160.Parse("0001020304050607080900010203040506070809");
+            var storages = new[] {
+                (key: new StorageKey { Key = Convert.FromHexString("01")}, value: new StorageItem(Convert.FromHexString("11121314"))),
+                (key: new StorageKey { Key = Convert.FromHexString("02")}, value: new StorageItem(Convert.FromHexString("21222324")))
+            };
+
+            var writer = new ArrayBufferWriter<byte>();
+            StorageRecord.Write(writer, options, scriptHash, storages);
+
+            var record = MessagePackSerializer.Deserialize<ITraceDebugRecord>(writer.WrittenMemory, options);
+
+            Assert.IsType<StorageRecord>(record);
+            if (record is StorageRecord storageRecord)
+            {
+                Assert.Equal(scriptHash, storageRecord.ScriptHash);
+                Assert.Equal(storages.Length, storageRecord.Storages.Count);
+            }
+        }
+        static void StorageRecord_WriteWithStorageItemArrayHeader(
+            IBufferWriter<byte> writer, MessagePackSerializerOptions options, UInt160 scriptHash,
+            IEnumerable<(StorageKey key, StorageItem item)> storages)
+        {
+            var count = storages.Count();
+            if (count <= 0) return;
+
+            var byteArrayFormatter = options.Resolver.GetFormatterWithVerify<byte[]>();
+            var storageItemFormatter = options.Resolver.GetFormatterWithVerify<StorageItem>();
+
+            var mpWriter = new MessagePackWriter(writer);
+            mpWriter.WriteArrayHeader(2);
+            mpWriter.WriteInt32(StorageRecord.RecordKey);
+            mpWriter.WriteArrayHeader(2);
+            options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref mpWriter, scriptHash, options);
+            mpWriter.WriteMapHeader(count);
+            foreach (var (key, item) in storages)
+            {
+                byteArrayFormatter.Serialize(ref mpWriter, key.Key, options);
+
+                mpWriter.WriteArrayHeader(1);
+                mpWriter.Write(item.Value);
+            }
+            mpWriter.Flush();
+        }
+
+        [Fact]
+        public void can_deserialize_uint160_raw()
+        {
+            var scriptHash = UInt160.Parse("0001020304050607080900010203040506070809");
+
+            var writer = new ArrayBufferWriter<byte>();
+            {
+                var mpWriter = new MessagePackWriter(writer);
+                mpWriter.WriteRaw(scriptHash.ToArray().AsSpan(0, UInt160.Length));
+                mpWriter.Flush();
+            }
+
+            var actual = MessagePackSerializer.Deserialize<UInt160>(writer.WrittenMemory, options);
+
+            Assert.Equal(scriptHash, actual);
+        }
+
+        [Fact]
+        public void can_deserialize_uint160_not_raw()
+        {
+            var scriptHash = UInt160.Parse("0001020304050607080900010203040506070809");
+
+            var writer = new ArrayBufferWriter<byte>();
+            MessagePackSerializer.Serialize<UInt160>(writer, scriptHash, options);
+
+            var actual = MessagePackSerializer.Deserialize<UInt160>(writer.WrittenMemory, options);
+
+            Assert.Equal(scriptHash, actual);
+        }
+    }
+}


### PR DESCRIPTION
* Added GasConsumed field to TraceRecord
* Add TraceRecordFormatter class to handle deserializing TraceRecords with and without gas Consumed field
* Update binary record writing 
* Optimize StorageItem serialization (and modify StorageItemFormatter to handle old + new serialization formats)
* Update UInt160 serialization (and modify UInt160Formatter to handle old + new serialization formats)
* Add Write overloads that take MessagePackWriter paramerter
* Swap ScriptIdentifier + ScriptHash to natch core platform
* Modify TraceRecord.Write to take a delegate to calculate script identifier instead of dictaing that the caller uses a dictionary cache
* added some trace model tests