### PR TITLE
Track instruction and branch execution in TestApplicationEngine

### DIFF
--- a/src/bctklib/Extensions.cs
+++ b/src/bctklib/Extensions.cs
@@ -170,6 +170,10 @@ namespace Neo.BlockchainToolkit
             }
         }
 
+        public static bool IsBranchInstruction(this Instruction instruction) 
+            => instruction.OpCode >= OpCode.JMPIF
+                && instruction.OpCode <= OpCode.JMPLE_L;
+
         public static string GetOperandString(this Instruction instruction)
         {
             return string.Create<ReadOnlyMemory<byte>>(instruction.Operand.Length * 3 - 1,

--- a/src/bctklib/persistence/NullStore.cs
+++ b/src/bctklib/persistence/NullStore.cs
@@ -8,7 +8,7 @@ namespace Neo.BlockchainToolkit.Persistence
 {
     public class NullStore : IReadOnlyStore
     {
-        public static NullStore Instance = new NullStore();
+        public static readonly NullStore Instance = new NullStore();
 
         private NullStore() { }
 

--- a/src/bctklib/smart-contract/TestApplicationEngine.cs
+++ b/src/bctklib/smart-contract/TestApplicationEngine.cs
@@ -194,6 +194,8 @@ namespace Neo.BlockchainToolkit.SmartContract
 
         protected override void PreExecuteInstruction()
         {
+            base.PreExecuteInstruction();
+
             if (CurrentContext == null) return;
             
             var hash = CurrentContext.GetScriptHash() 
@@ -226,6 +228,8 @@ namespace Neo.BlockchainToolkit.SmartContract
 
         protected override void PostExecuteInstruction()
         {
+            base.PostExecuteInstruction();
+
             if (CurrentContext == null) return;
 
             if (branchInstructionInfo != null)
@@ -254,8 +258,6 @@ namespace Neo.BlockchainToolkit.SmartContract
 
                 branchMap[branchInstructionInfo.InstructionPointer] = branchHit;
             }
-
-            base.PostExecuteInstruction();
         }
 
         private void OnLog(object? sender, LogEventArgs args)


### PR DESCRIPTION
This PR updates `TestApplicationEngine` to track instruction and branch execution for code coverage reporting purposes. `TestApplicationEngine` now records information about executed scripts and contracts, instruction and branch execution count for every instruction/branch in each script or contract. This information can be used to calculate line and branch code coverage information.

Other changes:
* Mark `NullStore` static instance as readonly
* Simplify overriding services in `TestApplicationEngine`