### PR TITLE
Enable Empty Prefix / Seek Backwards behavior

### DIFF
--- a/src/bctklib/persistence/Extensions.cs
+++ b/src/bctklib/persistence/Extensions.cs
@@ -25,15 +25,10 @@ namespace Neo.BlockchainToolkit.Persistence
 
         public static IEnumerable<(byte[] key, byte[] value)> Seek(this RocksDb db, ColumnFamilyHandle columnFamily, ReadOnlySpan<byte> prefix, SeekDirection direction, ReadOptions? readOptions)
         {
-            // Note, behavior of IReadOnlyStore.Seek method is inconsistent when key is empty and SeekDirection is backwards.
-            // MemoryStore returns all items in reverse order while LevelDbStore and RocksDbStore return an empty enumerable.
-            // This inconsistency is tracked by https://github.com/neo-project/neo/issues/2634.
-            // Luckily, the combination of empty key + backwards seek isn't used anywhere in the neo code base as of v3.0.3
-            // For now, explicitly throw in this situation rather than choosing one inconsistent behavior over the other
 
             if (prefix.Length == 0 && direction == SeekDirection.Backward)
             {
-                throw new InvalidOperationException("https://github.com/neo-project/neo/issues/2634");
+                return Enumerable.Empty<(byte[] key, byte[] value)>();
             }
 
             var iterator = db.NewIterator(columnFamily, readOptions);
@@ -93,12 +88,9 @@ namespace Neo.BlockchainToolkit.Persistence
         {
             key ??= Array.Empty<byte>();
 
-            // See note above in Seek(RocksDb, ColumnFamilyHandle, ReadOnlySpan<byte>, SeekDirection, ReadOptions?)
-            // regarding this InvalidOperationException 
-
             if (key.Length == 0 && direction == SeekDirection.Backward)
             {
-                throw new InvalidOperationException("https://github.com/neo-project/neo/issues/2634");
+                return Enumerable.Empty<(byte[] key, byte[] value)>();
             }
 
             var comparer = direction == SeekDirection.Forward

--- a/src/bctklib/persistence/Extensions.cs
+++ b/src/bctklib/persistence/Extensions.cs
@@ -25,12 +25,6 @@ namespace Neo.BlockchainToolkit.Persistence
 
         public static IEnumerable<(byte[] key, byte[] value)> Seek(this RocksDb db, ColumnFamilyHandle columnFamily, ReadOnlySpan<byte> prefix, SeekDirection direction, ReadOptions? readOptions)
         {
-
-            if (prefix.Length == 0 && direction == SeekDirection.Backward)
-            {
-                return Enumerable.Empty<(byte[] key, byte[] value)>();
-            }
-
             var iterator = db.NewIterator(columnFamily, readOptions);
 
             if (direction == SeekDirection.Forward)

--- a/src/bctklib/persistence/NullCheckpointStore.cs
+++ b/src/bctklib/persistence/NullCheckpointStore.cs
@@ -25,11 +25,7 @@ namespace Neo.BlockchainToolkit.Persistence
         }
 
         public IEnumerable<(byte[] Key, byte[]? Value)> Seek(byte[] key, SeekDirection direction)
-            // See note in Extensions.Seek(RocksDb, ColumnFamilyHandle, ReadOnlySpan<byte>, SeekDirection, ReadOptions?)
-            // regarding this InvalidOperationException 
-            => (key.Length == 0 && direction == SeekDirection.Backward)
-                ? throw new InvalidOperationException("https://github.com/neo-project/neo/issues/2634")
-                : Enumerable.Empty<(byte[], byte[]?)>();
+            => Enumerable.Empty<(byte[], byte[]?)>();
         public byte[]? TryGet(byte[] key) => null;
         public bool Contains(byte[] key) => false;
     }

--- a/src/bctklib/persistence/NullStore.cs
+++ b/src/bctklib/persistence/NullStore.cs
@@ -14,10 +14,6 @@ namespace Neo.BlockchainToolkit.Persistence
         public bool Contains(byte[]? key) => false;
         public byte[]? TryGet(byte[]? key) => null;
         public IEnumerable<(byte[] Key, byte[]? Value)> Seek(byte[] key, SeekDirection direction)
-            // See note in Extensions.Seek(RocksDb, ColumnFamilyHandle, ReadOnlySpan<byte>, SeekDirection, ReadOptions?)
-            // regarding this InvalidOperationException 
-            => (key.Length == 0 && direction == SeekDirection.Backward)
-                ? throw new InvalidOperationException("https://github.com/neo-project/neo/issues/2634")
-                : Enumerable.Empty<(byte[], byte[]?)>();
+            => Enumerable.Empty<(byte[], byte[]?)>();
     }
 }

--- a/src/bctklib/persistence/StateServiceStore.cs
+++ b/src/bctklib/persistence/StateServiceStore.cs
@@ -124,7 +124,7 @@ namespace Neo.BlockchainToolkit.Persistence
 
             if (key.Length == 0 && direction == SeekDirection.Backward)
             {
-                throw new InvalidOperationException("https://github.com/neo-project/neo/issues/2634");
+                return Enumerable.Empty<(byte[] key, byte[] value)>();
             }
 
             var contractId = BinaryPrimitives.ReadInt32LittleEndian(key.AsSpan(0, 4));

--- a/test/test.bctklib/CheckpointTest.cs
+++ b/test/test.bctklib/CheckpointTest.cs
@@ -72,13 +72,12 @@ namespace test.bctklib
             actual.Should().BeEquivalentTo(expected);
         }
 
-        [Fact(Skip = "https://github.com/neo-project/neo/issues/2634")]
+        [Fact]
         public void can_seek_backwards_no_prefix()
         {
             using var store = new CheckpointStore(fixture.CheckpointPath);
             var actual = store.Seek(Array.Empty<byte>(), SeekDirection.Backward).ToArray();
-            var expected = CheckpointFixture.GetSeekData().Reverse();
-            actual.Should().BeEquivalentTo(expected);
+            actual.Should().BeEmpty();
         }
 
         [Fact]

--- a/test/test.bctklib/MemoryTrackingStoreTest.cs
+++ b/test/test.bctklib/MemoryTrackingStoreTest.cs
@@ -196,14 +196,13 @@ namespace test.bctklib
             actual.Should().BeEquivalentTo(expected);
         }
 
-        [Fact(Skip = "https://github.com/neo-project/neo/issues/2634")]
+        [Fact]
         public void can_seek_backwards_no_prefix()
         {
             var store = GetSeekStore();
 
             var actual = store.Seek(Array.Empty<byte>(), SeekDirection.Backward);
-            var expected = GetSeekData().Reverse();
-            actual.Should().BeEquivalentTo(expected);
+            actual.Should().BeEmpty();
         }
 
         [Fact]

--- a/test/test.bctklib/RocksDbStoreTest.cs
+++ b/test/test.bctklib/RocksDbStoreTest.cs
@@ -214,16 +214,15 @@ namespace test.bctklib
             });
         }
 
-        [Fact(Skip = "https://github.com/neo-project/neo/issues/2634")]
+        [Fact]
         public void can_seek_backwards_no_prefix()
         {
             RunTestWithCleanup(path =>
             {
                 using var store = GetSeekStore(path);
 
-                var actual = store.Seek(Array.Empty<byte>(), SeekDirection.Forward).ToArray();
-                var expected = GetSeekData().Reverse().ToArray();
-                actual.Should().BeEquivalentTo(expected);
+                var actual = store.Seek(Array.Empty<byte>(), SeekDirection.Backward).ToArray();
+                actual.Should().BeEmpty();
             });
         }
 


### PR DESCRIPTION
Core team has [clarified](https://github.com/neo-project/neo/pull/2635) behavior of `IReadOnlyStore.Seek` when key is null/empty and direction is backwards to be an empty enumerator. This PR removes the exceptions thrown in this situation and updates all the `IReadOnlyStore` implementations in this library to correct behavior