### PR TITLE
return null instead of throwing exception if StateServiceStore doesn't have contract ID in the contract map

### DIFF
--- a/src/bctklib/persistence/StateServiceStore.cs
+++ b/src/bctklib/persistence/StateServiceStore.cs
@@ -399,7 +399,13 @@ namespace Neo.BlockchainToolkit.Persistence
                 return Array.Empty<(byte[], byte[])>();
             }
 
-            var contractHash = contractMap[contractId];
+            if (!contractMap.TryGetValue(contractId, out var contractHash))
+            {
+                // if contractId isn't in contractMap, the state service has no record of it at the
+                // branch index height. Return empty enumerable directly.
+                return Enumerable.Empty<(byte[] Key, byte[] Value)>();
+            }
+
             if (contractId < 0)
             {
                 var prefix = key.Span[0];
@@ -426,7 +432,7 @@ namespace Neo.BlockchainToolkit.Persistence
             }
 
             {
-                var states = FindStates(contractMap[contractId], null);
+                var states = FindStates(contractHash, null);
                 return ConvertStates(key, states);
             }
 

--- a/src/bctklib/persistence/StateServiceStore.cs
+++ b/src/bctklib/persistence/StateServiceStore.cs
@@ -286,7 +286,12 @@ namespace Neo.BlockchainToolkit.Persistence
                     $"{nameof(StateServiceStore)} does not support TryGet method for {nameof(NeoToken)} with {Convert.ToHexString(key.Span)} key");
             }
 
-            var contractHash = contractMap[contractId];
+            if (!contractMap.TryGetValue(contractId, out var contractHash))
+            {
+                // if contractId isn't in contractMap, the state service has no record of it at the
+                // branch index height. Return null directly.
+                return null;
+            }
 
             if (contractId < 0)
             {


### PR DESCRIPTION
StateServiceStore has a Dictionary mapping internal contract IDs to contract hashes. If a contract id is requested that is not in the map, StateServiceStore is throwing an exception. This code changes StateServiceStore to return null for TryGet and an empty enumerable for Seek if the contractId is not in the contract map.

fixes #84